### PR TITLE
Partially revert with plugin changes

### DIFF
--- a/thrift/src/main/resources/META-INF/plugin.xml
+++ b/thrift/src/main/resources/META-INF/plugin.xml
@@ -21,7 +21,8 @@
   <depends>com.intellij.modules.vcs</depends>
   <depends>com.intellij.modules.xml</depends>
   <depends>com.intellij.modules.xdebugger</depends>
-  <depends>com.intellij.java</depends>
+  <depends optional="true" config-file="withJava.xml">com.intellij.modules.java</depends>
+  <depends optional="true" config-file="withScala.xml">org.intellij.scala</depends>
 
   <application-components>
     <!-- Add your application components here -->
@@ -99,11 +100,4 @@
       <add-to-group group-id="RunContextPopupGroup" anchor="first"/>
     </action>
   </actions>
-
-  <extensions defaultExtensionNs="com.intellij">
-    <codeInsight.lineMarkerProvider language="JAVA"
-                                    implementationClass="com.intellij.plugins.thrift.editor.GoToThriftDefinitionMarkerProvider"/>
-    <codeInsight.lineMarkerProvider language="Scala"
-                                    implementationClass="com.intellij.plugins.thrift.editor.GoToThriftDefinitionMarkerProvider"/>
-  </extensions>
 </idea-plugin>

--- a/thrift/src/main/resources/META-INF/withJava.xml
+++ b/thrift/src/main/resources/META-INF/withJava.xml
@@ -1,0 +1,6 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <codeInsight.lineMarkerProvider language="JAVA"
+                                        implementationClass="com.intellij.plugins.thrift.editor.GoToThriftDefinitionMarkerProvider"/>
+    </extensions>
+</idea-plugin>

--- a/thrift/src/main/resources/META-INF/withScala.xml
+++ b/thrift/src/main/resources/META-INF/withScala.xml
@@ -1,0 +1,6 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <codeInsight.lineMarkerProvider language="Scala"
+                                        implementationClass="com.intellij.plugins.thrift.editor.GoToThriftDefinitionMarkerProvider"/>
+    </extensions>
+</idea-plugin>


### PR DESCRIPTION
- Partially revert changes related to removing dependent plugins
- Even though Java is required for normal plugin functioning for some cases it's okay without Java to make it work with other IDEs that don't have Java by default, for example GoLang. In that case only syntax highlight will work