### PR TITLE
Support Intellij IDEA 2023.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 
 plugins {
-    id "org.jetbrains.intellij" version "1.15.0" apply false
+    id "org.jetbrains.intellij" version "1.16.1" apply false
 }
 
 subprojects {
@@ -39,4 +39,8 @@ subprojects {
             events = Set.of(TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)
         }
     }
+
+    // Disable search options to improve build time since we don't provide any custom settings
+    // See: https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin-faq.html#how-to-disable-building-searchable-options
+    buildSearchableOptions.enabled = false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-ideaVersion=2023.2
-ideaSinceVersion=232.8660.185
+ideaVersion=2023.3
+ideaSinceVersion=233.11799.241
 sources=true
 isEAP=false
 

--- a/jps-plugin/build.gradle
+++ b/jps-plugin/build.gradle
@@ -1,6 +1,6 @@
 jar.archiveFileName = "thrift-jps.jar"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }

--- a/thrift/build.gradle
+++ b/thrift/build.gradle
@@ -9,8 +9,8 @@ publishPlugin {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 sourceSets {
@@ -24,6 +24,7 @@ sourceSets {
 
 dependencies {
     implementation project(':jps-plugin')
+    implementation 'org.apache.commons:commons-lang3:3.14.0'
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
     testImplementation("org.junit.platform:junit-platform-launcher:1.10.0")

--- a/thrift/src/main/java/com/intellij/plugins/thrift/config/ThriftCompilerConfigurable.java
+++ b/thrift/src/main/java/com/intellij/plugins/thrift/config/ThriftCompilerConfigurable.java
@@ -19,7 +19,7 @@ import com.intellij.ui.IdeBorderFactory;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBTextField;
 import com.intellij.util.ui.JBInsets;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/thrift/src/main/java/com/intellij/plugins/thrift/config/ThriftConfigService.java
+++ b/thrift/src/main/java/com/intellij/plugins/thrift/config/ThriftConfigService.java
@@ -2,8 +2,8 @@ package com.intellij.plugins.thrift.config;
 
 import com.intellij.openapi.components.*;
 import com.intellij.plugins.thrift.jps.ThriftProjectExtensionSerializer;
-import org.apache.commons.lang.BooleanUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jdom.Element;
 import org.jetbrains.annotations.Nullable;
 

--- a/thrift/src/main/java/com/intellij/plugins/thrift/config/facet/ThriftFacetConf.java
+++ b/thrift/src/main/java/com/intellij/plugins/thrift/config/facet/ThriftFacetConf.java
@@ -27,7 +27,7 @@ import com.intellij.plugins.thrift.config.target.GeneratorType;
 import com.intellij.ui.*;
 import com.intellij.ui.popup.PopupFactoryImpl;
 import com.intellij.util.ui.UIUtil;
-import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/thrift/src/main/java/com/intellij/plugins/thrift/config/facet/options/GoOptionPane.java
+++ b/thrift/src/main/java/com/intellij/plugins/thrift/config/facet/options/GoOptionPane.java
@@ -2,7 +2,7 @@ package com.intellij.plugins.thrift.config.facet.options;
 
 import com.intellij.plugins.thrift.ThriftBundle;
 import com.intellij.plugins.thrift.config.target.Go;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.swing.*;
 import java.awt.*;

--- a/thrift/src/main/java/com/intellij/plugins/thrift/config/facet/options/OptionsDialogWrapper.java
+++ b/thrift/src/main/java/com/intellij/plugins/thrift/config/facet/options/OptionsDialogWrapper.java
@@ -13,7 +13,7 @@ import com.intellij.plugins.thrift.config.target.Generator;
 import com.intellij.ui.IdeBorderFactory;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBTextField;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.io.LocalFileFinder;

--- a/thrift/src/main/java/com/intellij/plugins/thrift/config/facet/options/PHPOptionPane.java
+++ b/thrift/src/main/java/com/intellij/plugins/thrift/config/facet/options/PHPOptionPane.java
@@ -2,7 +2,7 @@ package com.intellij.plugins.thrift.config.facet.options;
 
 import com.intellij.plugins.thrift.ThriftBundle;
 import com.intellij.plugins.thrift.config.target.PHP;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.swing.*;
 import java.awt.*;

--- a/thrift/src/main/java/com/intellij/plugins/thrift/config/facet/options/PythonOptionPane.java
+++ b/thrift/src/main/java/com/intellij/plugins/thrift/config/facet/options/PythonOptionPane.java
@@ -2,7 +2,7 @@ package com.intellij.plugins.thrift.config.facet.options;
 
 import com.intellij.plugins.thrift.ThriftBundle;
 import com.intellij.plugins.thrift.config.target.Python;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.swing.*;
 import java.awt.*;

--- a/thrift/src/main/resources/META-INF/plugin.xml
+++ b/thrift/src/main/resources/META-INF/plugin.xml
@@ -9,7 +9,7 @@
   </description>
   <change-notes>
     <![CDATA[
-      Go to the Thrift source of implemented method.
+      IntelliJ 2023.3 Support
     ]]>
   </change-notes>
   <vendor>@arhont375</vendor>


### PR DESCRIPTION
* Upgrade versions in build.gradle/gradle.properties to support 2023.3
* Add `commons-lang3` dependency since `commons-lang2` and `commons-collections` libraries will be removed later (@see https://plugins.jetbrains.com/docs/intellij/api-changes-list-2023.html#kotlin-plugin-20233)
* Set `buildSearchableOptions.enabled=false` to improve build time since we don't have searchable options for intellij-thrift plugin

If you need to use the thrift plugin before this PR is merged, I have built a temp 1.7.0 version: [thrift-1.7.0.zip](https://github.com/arhont375/intellij-thrift/files/13593897/thrift-1.7.0.zip)