### PR TITLE
Fix 2024.1 support

### DIFF
--- a/jps-plugin/build.gradle
+++ b/jps-plugin/build.gradle
@@ -1,6 +1,6 @@
 jar.archiveFileName = "thrift-jps.jar"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }

--- a/thrift/build.gradle
+++ b/thrift/build.gradle
@@ -9,8 +9,8 @@ publishPlugin {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 sourceSets {

--- a/thrift/build.gradle
+++ b/thrift/build.gradle
@@ -1,7 +1,7 @@
 jar.archiveFileName = "plugin.jar"
 
 patchPluginXml {
-    version = System.getenv().getOrDefault("GITHUB_REF_NAME", "1.1.1")
+    version = System.getenv().getOrDefault("GITHUB_REF_NAME", "1.8.1")
 }
 
 publishPlugin {


### PR DESCRIPTION
- [x] Resolve this warning on build

```
> Task :jps-plugin:verifyPluginConfiguration
[gradle-intellij-plugin :jps-plugin jps-plugin:jps-plugin:verifyPluginConfiguration] The following plugin configuration issues were found:
- The Java configuration specifies sourceCompatibility=1.8 but IntelliJ Platform 2024.1 requires sourceCompatibility=17.
See: https://jb.gg/intellij-platform-versions

> Task :thrift:verifyPluginConfiguration
[gradle-intellij-plugin :thrift thrift:thrift:verifyPluginConfiguration] The following plugin configuration issues were found:
- The Java configuration specifies sourceCompatibility=11 but IntelliJ Platform 2024.1 requires sourceCompatibility=17.
See: https://jb.gg/intellij-platform-versions
```

- [x] Correct plugin version to `1.8.1`.