### PR TITLE
NO-ISSUE Remove unused ide plugins

### DIFF
--- a/thrift/src/main/resources/META-INF/plugin.xml
+++ b/thrift/src/main/resources/META-INF/plugin.xml
@@ -16,9 +16,7 @@
 
   <depends>com.intellij.modules.platform</depends>
   <depends>com.intellij.modules.lang</depends>
-  <depends>com.intellij.modules.vcs</depends>
-  <depends>com.intellij.modules.xml</depends>
-  <depends>com.intellij.modules.xdebugger</depends>
+
   <depends optional="true" config-file="withJava.xml">com.intellij.modules.java</depends>
   <depends optional="true" config-file="withScala.xml">org.intellij.scala</depends>
 


### PR DESCRIPTION
Seems like vcs plugin gonna be removed in 2024.2 and by the quick check it does seem to me that that functionality from this plugins is not used, so left only the one that should be used here.

Quickly confirmed with the tests and manual test.

https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html#modules-available-in-all-products