### PR TITLE
feat(folding): remove dependency to java plugin

### DIFF
--- a/thrift/src/main/java/com/intellij/plugins/thrift/lang/ThriftFoldingBuilder.java
+++ b/thrift/src/main/java/com/intellij/plugins/thrift/lang/ThriftFoldingBuilder.java
@@ -7,9 +7,11 @@ import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.plugins.thrift.lang.lexer.ThriftElementType;
-import com.intellij.psi.JavaRecursiveElementWalkingVisitor;
 import com.intellij.psi.PsiElement;
 import com.intellij.plugins.thrift.lang.psi.*;
+import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.PsiRecursiveVisitor;
+import com.intellij.psi.PsiWalkingState;
 import com.intellij.psi.tree.IElementType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -68,7 +70,10 @@ public class ThriftFoldingBuilder extends FoldingBuilderEx implements DumbAware 
     return false;
   }
 
-  static class ThriftFoldingRecursiveElementWalkingVisitor extends JavaRecursiveElementWalkingVisitor {
+  static class ThriftFoldingRecursiveElementWalkingVisitor extends PsiElementVisitor implements PsiRecursiveVisitor {
+    private final PsiWalkingState myWalkingState = new PsiWalkingState(this) {
+    };
+
     private final List<FoldingDescriptor> descriptors;
 
     public ThriftFoldingRecursiveElementWalkingVisitor(List<FoldingDescriptor> descriptors) {
@@ -77,7 +82,7 @@ public class ThriftFoldingBuilder extends FoldingBuilderEx implements DumbAware 
 
     @Override
     public void visitElement(@NotNull PsiElement element) {
-      super.visitElement(element);
+      myWalkingState.elementStarted(element);
 
       if (element instanceof ThriftEnum) {
         this.visitElementWithCurlyBraceChildren(element);

--- a/thrift/src/test/java/com/intellij/plugins/thrift/folding/ThriftFoldingBuilderTest.java
+++ b/thrift/src/test/java/com/intellij/plugins/thrift/folding/ThriftFoldingBuilderTest.java
@@ -1,7 +1,6 @@
 package com.intellij.plugins.thrift.folding;
 
 import com.intellij.plugins.thrift.ThriftCodeInsightFixtureTestCase;
-import org.junit.jupiter.api.Test;
 
 public class ThriftFoldingBuilderTest extends ThriftCodeInsightFixtureTestCase {
   @Override


### PR DESCRIPTION
When folding thrift files in non-java IDE(e.g. GoLand), `com.intellij.psi.JavaRecursiveElementWalkingVisitor` class cannot be loaded.

Root cause: java plugin not present.

So I removed the dependency to java plugin to make folding work in non-java IDE.

```
2024-07-02 21:34:07,174 [   1144] SEVERE - #c.i.o.u.KeyedExtensionCollector - Cannot load class com.intellij.plugins.thrift.lang.ThriftFoldingBuilder$ThriftFoldingRecursiveElementWalkingVisitor (
  error: com/intellij/psi/JavaRecursiveElementWalkingVisitor,
  classLoader=PluginClassLoader(plugin=PluginDescriptor(name=Thrift Support (fork), id=thrift-syntax-fork, descriptorPath=plugin.xml, path=~/Library/Application Support/JetBrains/GoLand2024.1/plugins/thrift, version=1.8.4, package=null, isBundled=false), packagePrefix=null, state=active)
)
com.intellij.diagnostic.PluginException: Cannot load class com.intellij.plugins.thrift.lang.ThriftFoldingBuilder$ThriftFoldingRecursiveElementWalkingVisitor (
  error: com/intellij/psi/JavaRecursiveElementWalkingVisitor,
  classLoader=PluginClassLoader(plugin=PluginDescriptor(name=Thrift Support (fork), id=thrift-syntax-fork, descriptorPath=plugin.xml, path=~/Library/Application Support/JetBrains/GoLand2024.1/plugins/thrift, version=1.8.4, package=null, isBundled=false), packagePrefix=null, state=active)
)
	at com.intellij.ide.plugins.cl.PluginClassLoader.loadClassInsideSelf(PluginClassLoader.kt:331)
	at com.intellij.ide.plugins.cl.PluginClassLoader.tryLoadingClass(PluginClassLoader.kt:178)
	at com.intellij.ide.plugins.cl.PluginClassLoader.loadClass(PluginClassLoader.kt:151)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
	at java.base/java.lang.invoke.MethodHandleNatives.resolve(Native Method)
	at java.base/java.lang.invoke.MemberName$Factory.resolve(MemberName.java:1085)
	at java.base/java.lang.invoke.MemberName$Factory.resolveOrFail(MemberName.java:1114)
	at java.base/java.lang.invoke.MethodHandles$Lookup.resolveOrFail(MethodHandles.java:3649)
	at java.base/java.lang.invoke.MethodHandles$Lookup.findConstructor(MethodHandles.java:2750)
	at com.intellij.serviceContainer.ComponentManagerImplKt.findConstructorOrNull(ComponentManagerImpl.kt:84)
	at com.intellij.serviceContainer.ComponentManagerImpl.findConstructorAndInstantiateClass(ComponentManagerImpl.kt:908)
	at com.intellij.serviceContainer.ComponentManagerImpl.doInstantiateClass(ComponentManagerImpl.kt:917)
	at com.intellij.serviceContainer.ComponentManagerImpl.instantiateClass(ComponentManagerImpl.kt:902)
	at com.intellij.serviceContainer.ComponentManagerImpl.instantiateClass(ComponentManagerImpl.kt:943)
	at com.intellij.serviceContainer.LazyExtensionInstance.createInstance(LazyExtensionInstance.java:55)
	at com.intellij.serviceContainer.LazyExtensionInstance.getInstance(LazyExtensionInstance.java:44)
	at com.intellij.serviceContainer.BaseKeyedLazyInstance.getInstance(BaseKeyedLazyInstance.java:38)
	at com.intellij.openapi.util.KeyedExtensionCollector.instantiate(KeyedExtensionCollector.java:199)
	at com.intellij.openapi.util.KeyedExtensionCollector.buildExtensionsFromExtensionPoint(KeyedExtensionCollector.java:161)
	at com.intellij.openapi.util.KeyedExtensionCollector.buildExtensions(KeyedExtensionCollector.java:134)
	at com.intellij.lang.LanguageExtension.buildExtensions(LanguageExtension.java:134)
	at com.intellij.lang.LanguageExtension.buildExtensions(LanguageExtension.java:19)
	at com.intellij.openapi.util.KeyedExtensionCollector.forKey(KeyedExtensionCollector.java:111)
	at com.intellij.lang.folding.LanguageFolding.allForLanguage(LanguageFolding.java:60)
	at com.intellij.lang.folding.LanguageFolding.findForLanguage(LanguageFolding.java:42)
	at com.intellij.lang.folding.LanguageFolding.findForLanguage(LanguageFolding.java:21)
	at com.intellij.lang.LanguageExtension.forLanguage(LanguageExtension.java:93)
	at com.intellij.lang.folding.LanguageFolding.forLanguage(LanguageFolding.java:37)
	at com.intellij.codeInsight.folding.impl.FoldingUpdate.getFoldingsFor(FoldingUpdate.java:264)
	at com.intellij.codeInsight.folding.impl.FoldingUpdate.getFoldingsFor(FoldingUpdate.java:240)
	at com.intellij.codeInsight.folding.impl.CodeFoldingManagerImpl.buildInitialFoldings(CodeFoldingManagerImpl.java:143)
	at com.intellij.openapi.fileEditor.impl.text.FoldingTextEditorInitializer$initializeEditor$foldingState$1$1$1.invoke(FoldingTextEditorInitializer.kt:32)
	at com.intellij.openapi.fileEditor.impl.text.FoldingTextEditorInitializer$initializeEditor$foldingState$1$1$1.invoke(FoldingTextEditorInitializer.kt:31)
	at com.intellij.openapi.progress.CoroutinesKt.jobToIndicator$lambda$2(coroutines.kt:422)
	at com.intellij.openapi.progress.ProgressManager.lambda$runProcess$0(ProgressManager.java:100)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:217)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$13(CoreProgressManager.java:660)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:735)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:691)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:659)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:79)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:202)
	at com.intellij.openapi.progress.ProgressManager.runProcess(ProgressManager.java:100)
	at com.intellij.openapi.progress.CoroutinesKt.jobToIndicator(coroutines.kt:410)
	at com.intellij.openapi.progress.CoroutinesKt.contextToIndicator(coroutines.kt:402)
	at com.intellij.openapi.progress.CoroutinesKt.blockingContextToIndicator(coroutines.kt:381)
	at com.intellij.openapi.fileEditor.impl.text.FoldingTextEditorInitializer$initializeEditor$foldingState$1$1.invoke(FoldingTextEditorInitializer.kt:31)
	at com.intellij.openapi.fileEditor.impl.text.FoldingTextEditorInitializer$initializeEditor$foldingState$1$1.invoke(FoldingTextEditorInitializer.kt:30)
	at com.intellij.openapi.fileEditor.impl.text.PsiAwareTextEditorImplKt.catchingExceptions(PsiAwareTextEditorImpl.kt:105)
	at com.intellij.openapi.fileEditor.impl.text.FoldingTextEditorInitializer$initializeEditor$foldingState$1.invoke(FoldingTextEditorInitializer.kt:30)
	at com.intellij.openapi.fileEditor.impl.text.FoldingTextEditorInitializer$initializeEditor$foldingState$1.invoke(FoldingTextEditorInitializer.kt:28)
	at com.intellij.openapi.application.rw.InternalReadAction.insideReadAction(InternalReadAction.kt:108)
	at com.intellij.openapi.application.rw.InternalReadAction.access$insideReadAction(InternalReadAction.kt:16)
	at com.intellij.openapi.application.rw.InternalReadAction$tryReadCancellable$2.invoke(InternalReadAction.kt:95)
	at com.intellij.openapi.application.rw.InternalReadAction$tryReadCancellable$2.invoke(InternalReadAction.kt:94)
	at com.intellij.openapi.application.rw.CancellableReadActionKt$cancellableReadActionInternal$1.invoke$lambda$1$lambda$0(cancellableReadAction.kt:38)
	at com.intellij.openapi.application.impl.RwLockHolder.tryRunReadAction(RwLockHolder.kt:310)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:958)
	at com.intellij.openapi.application.rw.CancellableReadActionKt$cancellableReadActionInternal$1.invoke$lambda$1(cancellableReadAction.kt:36)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtilService.runActionAndCancelBeforeWrite(ProgressIndicatorUtilService.java:66)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.runActionAndCancelBeforeWrite(ProgressIndicatorUtils.java:155)
	at com.intellij.openapi.application.rw.CancellableReadActionKt$cancellableReadActionInternal$1.invoke(cancellableReadAction.kt:34)
	at com.intellij.openapi.progress.CoroutinesKt.blockingContextInner(coroutines.kt:320)
	at com.intellij.openapi.progress.CoroutinesKt.blockingContext(coroutines.kt:309)
	at com.intellij.openapi.application.rw.CancellableReadActionKt.cancellableReadActionInternal(cancellableReadAction.kt:31)
	at com.intellij.openapi.application.rw.InternalReadAction.tryReadCancellable(InternalReadAction.kt:94)
	at com.intellij.openapi.application.rw.InternalReadAction.tryReadAction(InternalReadAction.kt:78)
	at com.intellij.openapi.application.rw.InternalReadAction.readLoop(InternalReadAction.kt:65)
	at com.intellij.openapi.application.rw.InternalReadAction.access$readLoop(InternalReadAction.kt:16)
	at com.intellij.openapi.application.rw.InternalReadAction$runReadAction$4.invokeSuspend(InternalReadAction.kt:44)
	at com.intellij.openapi.application.rw.InternalReadAction$runReadAction$4.invoke(InternalReadAction.kt)
	at com.intellij.openapi.application.rw.InternalReadAction$runReadAction$4.invoke(InternalReadAction.kt)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:78)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:167)
	at kotlinx.coroutines.BuildersKt.withContext(Unknown Source)
	at com.intellij.openapi.application.rw.InternalReadAction.runReadAction(InternalReadAction.kt:40)
	at com.intellij.openapi.application.rw.PlatformReadWriteActionSupport.executeReadAction(PlatformReadWriteActionSupport.kt:38)
	at com.intellij.openapi.application.ReadWriteActionSupport.executeReadAction$default(ReadWriteActionSupport.kt:15)
	at com.intellij.openapi.application.CoroutinesKt.constrainedReadAction(coroutines.kt:58)
	at com.intellij.openapi.application.CoroutinesKt.readAction(coroutines.kt:25)
	at com.intellij.openapi.fileEditor.impl.text.FoldingTextEditorInitializer.initializeEditor(FoldingTextEditorInitializer.kt:28)
	at com.intellij.openapi.fileEditor.impl.text.PsiAwareTextEditorProvider$createEditorBuilder$2$task$1$1$1.invokeSuspend(PsiAwareTextEditorProvider.kt:95)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:584)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:793)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:697)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:684)
Caused by: java.lang.NoClassDefFoundError: com/intellij/psi/JavaRecursiveElementWalkingVisitor
	at java.base/java.lang.ClassLoader.defineClass2(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1108)
	at com.intellij.util.lang.UrlClassLoader.consumeClassData(UrlClassLoader.java:291)
	at com.intellij.util.lang.ZipResourceFile.findClass(ZipResourceFile.java:116)
	at com.intellij.util.lang.JarLoader.findClass(JarLoader.java:58)
	at com.intellij.util.lang.ClassPath.findClassInLoader(ClassPath.java:240)
	at com.intellij.util.lang.ClassPath.findClass(ClassPath.java:190)
	at com.intellij.ide.plugins.cl.PluginClassLoader.loadClassInsideSelf(PluginClassLoader.kt:326)
	... 87 more
Caused by: java.lang.ClassNotFoundException: com.intellij.psi.JavaRecursiveElementWalkingVisitor PluginClassLoader(plugin=PluginDescriptor(name=Thrift Support (fork), id=thrift-syntax-fork, descriptorPath=plugin.xml, path=~/Library/Application Support/JetBrains/GoLand2024.1/plugins/thrift, version=1.8.4, package=null, isBundled=false), packagePrefix=null, state=active)
	at com.intellij.ide.plugins.cl.PluginClassLoader.loadClass(PluginClassLoader.kt:156)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
	... 95 more
```
	