### PR TITLE
feat(folding): support type annotations, throws and function args

### DIFF
--- a/thrift/src/main/gen/com/intellij/plugins/thrift/lang/parser/ThriftParser.java
+++ b/thrift/src/main/gen/com/intellij/plugins/thrift/lang/parser/ThriftParser.java
@@ -863,7 +863,7 @@ public class ThriftParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // Identifier ('=' Literal ListSeparator?)?
+  // Identifier ('=' Literal)? ListSeparator?
   public static boolean TypeAnnotation(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "TypeAnnotation")) return false;
     if (!nextTokenIs(b, IDENTIFIER)) return false;
@@ -871,31 +871,31 @@ public class ThriftParser implements PsiParser, LightPsiParser {
     Marker m = enter_section_(b);
     r = consumeToken(b, IDENTIFIER);
     r = r && TypeAnnotation_1(b, l + 1);
+    r = r && TypeAnnotation_2(b, l + 1);
     exit_section_(b, m, TYPE_ANNOTATION, r);
     return r;
   }
 
-  // ('=' Literal ListSeparator?)?
+  // ('=' Literal)?
   private static boolean TypeAnnotation_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "TypeAnnotation_1")) return false;
     TypeAnnotation_1_0(b, l + 1);
     return true;
   }
 
-  // '=' Literal ListSeparator?
+  // '=' Literal
   private static boolean TypeAnnotation_1_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "TypeAnnotation_1_0")) return false;
     boolean r;
     Marker m = enter_section_(b);
     r = consumeTokens(b, 0, EQUALS, LITERAL);
-    r = r && TypeAnnotation_1_0_2(b, l + 1);
     exit_section_(b, m, null, r);
     return r;
   }
 
   // ListSeparator?
-  private static boolean TypeAnnotation_1_0_2(PsiBuilder b, int l) {
-    if (!recursion_guard_(b, l, "TypeAnnotation_1_0_2")) return false;
+  private static boolean TypeAnnotation_2(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "TypeAnnotation_2")) return false;
     ListSeparator(b, l + 1);
     return true;
   }

--- a/thrift/src/main/gen/com/intellij/plugins/thrift/lang/psi/ThriftDefinitionName.java
+++ b/thrift/src/main/gen/com/intellij/plugins/thrift/lang/psi/ThriftDefinitionName.java
@@ -15,8 +15,7 @@ public interface ThriftDefinitionName extends PsiNamedElement, NavigationItem, P
 
   @NotNull PsiElement setName(String name);
 
-  @NonNls
-  @Nullable String getName();
+  @Nullable @NonNls String getName();
 
   @NotNull PsiElement getNameIdentifier();
 

--- a/thrift/src/main/gen/com/intellij/plugins/thrift/lang/psi/impl/ThriftDefinitionNameImpl.java
+++ b/thrift/src/main/gen/com/intellij/plugins/thrift/lang/psi/impl/ThriftDefinitionNameImpl.java
@@ -39,8 +39,7 @@ public class ThriftDefinitionNameImpl extends ThriftPsiCompositeElementImpl impl
   }
 
   @Override
-  @NonNls
-  public @Nullable String getName() {
+  public @Nullable @NonNls String getName() {
     return ThriftPsiUtil.getName(this);
   }
 

--- a/thrift/src/main/grammar/Thrift.bnf
+++ b/thrift/src/main/grammar/Thrift.bnf
@@ -163,6 +163,6 @@ ListSeparator   ::=  ',' | ';'
 
 TypeAnnotations ::= '(' TypeAnnotationList ')'
 TypeAnnotationList ::= TypeAnnotation* {recoverWhile=braceRecovery}
-TypeAnnotation ::= Identifier ('=' Literal ListSeparator?)?
+TypeAnnotation ::= Identifier ('=' Literal)? ListSeparator?
 
 private braceRecovery ::= !(')')

--- a/thrift/src/test/java/com/intellij/plugins/thrift/folding/ThriftFoldingBuilderTest.java
+++ b/thrift/src/test/java/com/intellij/plugins/thrift/folding/ThriftFoldingBuilderTest.java
@@ -22,4 +22,8 @@ public class ThriftFoldingBuilderTest extends ThriftCodeInsightFixtureTestCase {
   public void testFoldingTwice() throws Throwable {
     doTest();
   }
+
+  public void testFoldingAnnotation() throws Throwable {
+    doTest();
+  }
 }

--- a/thrift/src/test/resources/folding/foldingAnnotation.thrift
+++ b/thrift/src/test/resources/folding/foldingAnnotation.thrift
@@ -1,0 +1,141 @@
+<fold text='/*...*/'>/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */</fold>
+
+typedef list<i32> ( cpp.template = "std::list" ) int_linked_list
+
+struct foo <fold text='{...}'>{
+  1: i32 bar ( presence = "required" );
+  2: i32 baz ( presence = "manual", cpp.use_pointer = "", );
+  3: i32 qux;
+  4: i32 bop;
+}</fold> <fold text='(...)'>(
+  cpp.type = "DenseFoo",
+  python.type = "DenseFoo",
+  java.final = "",
+  annotation.without.value,
+)</fold>
+
+exception foo_error <fold text='{...}'>{
+  1: i32 error_code ( foo="bar" )
+  2: string error_msg
+}</fold> (foo = "bar")
+
+typedef string ( unicode.encoding = "UTF-16" ) non_latin_string (foo="bar")
+typedef list< double ( cpp.fixed_point = "16" ) > tiny_float_list
+
+enum weekdays <fold text='{...}'>{
+  SUNDAY ( weekend = "yes" ),
+  MONDAY,
+  TUESDAY,
+  WEDNESDAY,
+  THURSDAY,
+  FRIDAY,
+  SATURDAY ( weekend = "yes" )
+}</fold> (foo.bar="baz")
+
+struct ostr_default <fold text='{...}'>{
+  1: i32 bar;
+}</fold>
+
+struct ostr_custom <fold text='{...}'>{
+  1: i32 bar;
+}</fold> (cpp.customostream)
+
+
+service foo_service <fold text='{...}'>{
+  void foo() ( foo = "bar" )
+}</fold> (a.b="c")
+
+service deprecate_everything <fold text='{...}'>{
+  void Foo( ) ( deprecated = "This method has neither 'x' nor \"y\"" )
+  void Bar( ) ( deprecated = "Fails to deliver 中文 колбаса" )
+  void Baz( ) ( deprecated = "Need this to work with tabs (\t) or Umlauts (äöüÄÖÜß) too" )
+  void Deprecated() ( deprecated ) // no comment
+}</fold>
+]]
+Expected [[<fold text='/*...*/'>/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */</fold>
+
+typedef list<i32> ( cpp.template = "std::list" ) int_linked_list
+
+struct foo <fold text='{...}'>{
+  1: i32 bar ( presence = "required" );
+  2: i32 baz ( presence = "manual", cpp.use_pointer = "", );
+  3: i32 qux;
+  4: i32 bop;
+}</fold> <fold text='(...)'>(
+  cpp.type = "DenseFoo",
+  python.type = "DenseFoo",
+  java.final = "",
+  annotation.without.value,
+)</fold>
+
+exception foo_error <fold text='{...}'>{
+  1: i32 error_code ( foo="bar" )
+  2: string error_msg
+}</fold> (foo = "bar")
+
+typedef string ( unicode.encoding = "UTF-16" ) non_latin_string (foo="bar")
+typedef list< double ( cpp.fixed_point = "16" ) > tiny_float_list
+
+enum weekdays <fold text='{...}'>{
+  SUNDAY ( weekend = "yes" ),
+  MONDAY,
+  TUESDAY,
+  WEDNESDAY,
+  THURSDAY,
+  FRIDAY,
+  SATURDAY ( weekend = "yes" )
+}</fold> (foo.bar="baz")
+
+struct ostr_default <fold text='{...}'>{
+  1: i32 bar;
+}</fold>
+
+struct ostr_custom <fold text='{...}'>{
+  1: i32 bar;
+}</fold> (cpp.customostream)
+
+
+service foo_service <fold text='{...}'>{
+  void foo() ( foo = "bar" )
+}</fold> (a.b="c")
+
+service deprecate_everything <fold text='{...}'>{
+  void Foo( ) ( deprecated = "This method has neither 'x' nor \"y\"" )
+  void Bar( ) ( deprecated = "Fails to deliver 中文 колбаса" )
+  void Baz( ) ( deprecated = "Need this to work with tabs (\t) or Umlauts (äöüÄÖÜß) too" )
+  void Deprecated() ( deprecated ) // no comment
+}</fold>

--- a/thrift/src/test/resources/folding/foldingTwice.thrift
+++ b/thrift/src/test/resources/folding/foldingTwice.thrift
@@ -1,3 +1,18 @@
+service SomeService <fold text='{...}'>{
+    void someFunc1(1: string req) throws <fold text='(...)'>(
+        1: i64 code
+    )</fold> (very_important)
+    void someFunc2(1: string req) <fold text='(...)'>(
+        not_important,
+    )</fold>
+    void someFunc3(1: string req) <fold text='(...)'>(very_lonnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnng_anno)</fold>
+    void someFunc4<fold text='(...)'>(1: string very_lonnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnng_req)</fold>
+    void someFunc5<fold text='(...)'>(
+        1: string req1,
+        2: string req2,
+    )</fold>
+}</fold>
+
 struct SomeStruct1 <fold text='{...}'>{
     1: i32 someField1
     3: i32 someField2


### PR DESCRIPTION
Changes:
* `parser`: change grammar to fix type annotations separator. This [file](https://github.com/apache/thrift/blob/86b05bf2294de5202f22033a2713f100c493b067/test/AnnotationTest.thrift) from official repo cannot be parsed before.
* `folding`: support type annotations, throws and function args