### PR TITLE
fix(formatter): provide language to avoid PluginException

### DIFF
--- a/thrift/src/main/java/com/intellij/plugins/thrift/formatter/ThriftCodeStyleSettingsProvider.java
+++ b/thrift/src/main/java/com/intellij/plugins/thrift/formatter/ThriftCodeStyleSettingsProvider.java
@@ -3,17 +3,25 @@ package com.intellij.plugins.thrift.formatter;
 import com.intellij.application.options.CodeStyleAbstractConfigurable;
 import com.intellij.application.options.CodeStyleAbstractPanel;
 import com.intellij.application.options.TabbedLanguageCodeStylePanel;
+import com.intellij.lang.Language;
 import com.intellij.plugins.thrift.ThriftLanguage;
 import com.intellij.psi.codeStyle.CodeStyleConfigurable;
 import com.intellij.psi.codeStyle.CodeStyleSettings;
 import com.intellij.psi.codeStyle.CodeStyleSettingsProvider;
 import com.intellij.psi.codeStyle.CustomCodeStyleSettings;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class ThriftCodeStyleSettingsProvider extends CodeStyleSettingsProvider {
   @Override
   public CustomCodeStyleSettings createCustomSettings(@NotNull CodeStyleSettings settings) {
     return new ThriftCodeStyleSettings(settings);
+  }
+
+  @Nullable
+  @Override
+  public Language getLanguage() {
+    return ThriftLanguage.INSTANCE;
   }
 
   @Override

--- a/thrift/src/test/java/com/intellij/plugins/thrift/formatter/ThriftCodeStyleSettingsProviderTest.java
+++ b/thrift/src/test/java/com/intellij/plugins/thrift/formatter/ThriftCodeStyleSettingsProviderTest.java
@@ -1,0 +1,20 @@
+package com.intellij.plugins.thrift.formatter;
+
+import com.intellij.plugins.thrift.ThriftLanguage;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ThriftCodeStyleSettingsProviderTest {
+
+  @Test
+  public void testGetLanguage() {
+    ThriftCodeStyleSettingsProvider provider = new ThriftCodeStyleSettingsProvider();
+    Assertions.assertEquals(ThriftLanguage.INSTANCE, provider.getLanguage(), "getLanguage should return ThriftLanguage.INSTANCE");
+  }
+
+  @Test
+  public void testGetConfigurableDisplayName() {
+    ThriftCodeStyleSettingsProvider provider = new ThriftCodeStyleSettingsProvider();
+    Assertions.assertEquals(ThriftLanguage.INSTANCE.getDisplayName(), provider.getConfigurableDisplayName());
+  }
+}


### PR DESCRIPTION
Overridden getLanguage() in ThriftCodeStyleSettingsProvider to return ThriftLanguage.INSTANCE. This prevents a PluginException that occurs when IntelliJ attempts to calculate the configurable ID using the legacy calculation mode from the localizable name. Also added unit tests to ensure the language and configurable display name are returned correctly.

see issue https://github.com/arhont375/intellij-thrift/issues/47